### PR TITLE
updated image name in from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM registry.access.redhat.com/jboss-eap-6/eap-openshift
+FROM registry.access.redhat.com/jboss-eap-6/eap64-openshift
+
 MAINTAINER lawnjarae
 
-# COPY deployments/ROOT.war $JBOSS_HOME/standalone/deployments/ROOT.war
 RUN echo "Copying rhn_ose_license.txt to $JBOSS_HOME/" > /tmp/rhn_output.txt
-COPY rhn_ose_license.txt $JBOSS_HOME/
 
-#RUN echo 'RHC Bootcamp Middleware License\n This software is meets the standard set forth by the company and can be used within all deployment environments' >> ${JBOSS_HOME}/rhc-ose-license.txt
+COPY rhn_ose_license.txt $JBOSS_HOME/


### PR DESCRIPTION
fixed image in dockerfile from line to correct name and will now be found. to test execute

```
oc new-app https://github.com/lawnjarae/eap-openshift-rhc-license.git
```

in ose environment of your choosing and verify the output and that the build succeeded.
